### PR TITLE
fix: indices problem on reppoints

### DIFF
--- a/mmdet/models/task_modules/assigners/point_assigner.py
+++ b/mmdet/models/task_modules/assigners/point_assigner.py
@@ -104,7 +104,7 @@ class PointAssigner(BaseAssigner):
         assigned_gt_inds = points.new_zeros((num_points, ), dtype=torch.long)
         # stores the assigned gt dist (to this point) of each point
         assigned_gt_dist = points.new_full((num_points, ), float('inf'))
-        points_range = torch.arange(points.shape[0])
+        points_range = torch.arange(points.shape[0], device=points_lvl.device)
 
         for idx in range(num_gts):
             gt_lvl = gt_bboxes_lvl[idx]


### PR DESCRIPTION
## Motivation

```
2024-12-12 20:00:27.940	
  File "/root/miniconda3/envs/avi/lib/python3.9/site-packages/mmdet/models/task_modules/assigners/point_assigner.py", line 113, in assign
2024-12-12 20:00:27.940	
    points_index = points_range[lvl_idx]
2024-12-12 20:00:27.940	
RuntimeError: indices should be either on cpu or on the same device as the indexed tensor (cpu)
```
